### PR TITLE
Batch CAN frame updates via timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A powerful, vendor-independent **desktop-based GUI application** for working wit
 - ✅ Modular and extensible architecture
 - ✅ Clean PySide6 UI with navigation across pages
 - ✅ Future-ready for any hardware vendor (supports plug-in drivers)
+- ✅ Batched frame updates with configurable refresh interval
 
 ---
 
@@ -82,3 +83,10 @@ can_diagnostic_tool/
 - cantools
 - pyqtgraph (for plotting)
 - pywin32 (for Windows GPS API)
+
+## Frame Update Batching
+
+Incoming CAN frames are collected in a background queue and applied to the table
+in batches. A timer (50 ms by default) controls how often queued frames are
+flushed to the UI. Pass a different `refresh_interval` when creating
+`CANFramePage` to tune the refresh rate.

--- a/threads/receiver_thread.py
+++ b/threads/receiver_thread.py
@@ -1,21 +1,29 @@
 # threads/receiver_thread.py
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import QThread
+from queue import Queue
 
 class CANReceiverThread(QThread):
-    frame_received = Signal(object)  # Emits: CANFrame object
 
     def __init__(self, can_interface):
         super().__init__()
         self.can_interface = can_interface
         self._running = True
+        self._queue: Queue = Queue()
 
     def run(self):
         while self._running:
             # Block for up to 10 ms, return earlier if a frame is available
             frame = self.can_interface.receive(timeout=10)
             if frame:
-                self.frame_received.emit(frame)
+                self._queue.put(frame)
 
     def stop(self):
         self._running = False
         self.wait()
+
+    def get_all_frames(self):
+        """Return a list of all frames currently queued."""
+        frames = []
+        while not self._queue.empty():
+            frames.append(self._queue.get())
+        return frames

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import (
     QPushButton, QStackedWidget, QLabel
 )
 from threads.receiver_thread import CANReceiverThread
-from can_frame.frame_page import CANFramePage  # NEW IMPORT
+from can_frame.frame_page import CANFramePage
 
 class MainWindow(QMainWindow):
     def __init__(self, can_interface):
@@ -36,15 +36,14 @@ class MainWindow(QMainWindow):
         self.pages.addWidget(self.home_page)
 
         # === Page 1: CAN Frame ===
-        self.can_frame_page = CANFramePage()
+        self.receiver_thread = CANReceiverThread(self.can_interface)
+        self.can_frame_page = CANFramePage(self.receiver_thread)
         self.pages.addWidget(self.can_frame_page)
 
         self.home_button.clicked.connect(lambda: self.pages.setCurrentWidget(self.home_page))
         self.can_frame_button.clicked.connect(lambda: self.pages.setCurrentWidget(self.can_frame_page))
 
         # === Receiver Thread ===
-        self.receiver_thread = CANReceiverThread(self.can_interface)
-        self.receiver_thread.frame_received.connect(self.can_frame_page.update_table)
         self.receiver_thread.start()
 
     def closeEvent(self, event):


### PR DESCRIPTION
## Summary
- queue incoming CAN frames instead of signalling each one
- process pending frames every 50 ms in `CANFramePage`
- adapt table update method for batches
- document batching and refresh rate

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a4697a11c8331b84977513a45d847