### PR TITLE
Implement multi-frame receive in CAN interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ can_diagnostic_tool/
 - cantools
 - pyqtgraph (for plotting)
 - pywin32 (for Windows GPS API)
+
+## Receiving Frames
+
+The receiver thread calls `CANInterface.receive()` which now accepts an optional
+`max_msgs` argument. The interface allocates space for multiple frames and
+returns a list of `CANFrame` objects for all messages read in one call. The
+thread iterates over this list and emits each frame individually to the UI.

--- a/hardware/can_interface.py
+++ b/hardware/can_interface.py
@@ -31,11 +31,11 @@ class CANInterface:
         frame.data = data
         return self.api.SBusCanSendMgs(frame)
 
-    def receive(self, timeout=10):
-        status, frame = self.api.SBusCanReadMgs(timeout)
+    def receive(self, timeout=10, max_msgs=10):
+        status, frames = self.api.SBusCanReadMgs(timeout, max_msgs)
         if status == 0:
-            return frame
-        return None
+            return frames
+        return []
 
     def set_filter(self, can_id):
         return self.api.SBusCanRxSetFilter(can_id)

--- a/threads/receiver_thread.py
+++ b/threads/receiver_thread.py
@@ -11,9 +11,9 @@ class CANReceiverThread(QThread):
 
     def run(self):
         while self._running:
-            # Block for up to 10 ms, return earlier if a frame is available
-            frame = self.can_interface.receive(timeout=10)
-            if frame:
+            # Block for up to 10 ms, return earlier if frames are available
+            frames = self.can_interface.receive(timeout=10, max_msgs=10)
+            for frame in frames:
                 self.frame_received.emit(frame)
 
     def stop(self):


### PR DESCRIPTION
## Summary
- support reading multiple CAN messages at once in j2534 driver
- allow CANInterface.receive() to return a list of frames
- handle multiple frames in CANReceiverThread
- document multi-frame receive behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a543ec2c08331bab5be62c31d0e12