### PR TITLE
Remove unused imports from sloki driver

### DIFF
--- a/hardware/drivers/j2534_sloki_driver.py
+++ b/hardware/drivers/j2534_sloki_driver.py
@@ -6,9 +6,7 @@
 # ------------------------------------------------------------
 
 import ctypes
-import os
 from enum import Enum
-import winreg
 
 # Generic CAN frame structure
 class CANFrame:


### PR DESCRIPTION
## Summary
- clean up j2534_sloki_driver imports

## Testing
- `python -m py_compile hardware/drivers/j2534_sloki_driver.py`

------
https://chatgpt.com/codex/tasks/task_e_687b780990d08331926628dfa974450a