### PR TITLE
Allow resetting driver frame counters

### DIFF
--- a/can_frame/frame_page.py
+++ b/can_frame/frame_page.py
@@ -65,3 +65,5 @@ class CANFramePage(QWidget):
         for can_id, row in self.can_id_to_row.items():
             self.frame_count[can_id] = 0
             self.table.setItem(row, 4, QTableWidgetItem("0"))
+        if hasattr(self, "can_interface") and hasattr(self.can_interface, "reset_rx_stats"):
+            self.can_interface.reset_rx_stats()

--- a/hardware/can_interface.py
+++ b/hardware/can_interface.py
@@ -39,3 +39,7 @@ class CANInterface:
 
     def set_filter(self, can_id):
         return self.api.SBusCanRxSetFilter(can_id)
+
+    def reset_rx_stats(self):
+        if hasattr(self.api, "reset_rx_stats"):
+            self.api.reset_rx_stats()

--- a/hardware/drivers/j2534_sloki_driver.py
+++ b/hardware/drivers/j2534_sloki_driver.py
@@ -7,6 +7,7 @@
 
 import ctypes
 import os
+import time
 from enum import Enum
 import winreg
 
@@ -28,6 +29,11 @@ class J2534API:
         self.j2534_dll = ctypes.WinDLL(r'C:\Program Files (x86)\Sloki\SBUS\lib\x64\sBus-J2534.dll')
         self.device_id = ctypes.c_ulong()
         self.channel_id = ctypes.c_ulong()
+        # RX statistics
+        self.total_rx = 0
+        self.rx_rate = 0
+        self._rx_sec_counter = 0
+        self._rx_sec_start = time.time()
 
     # C struct for CAN messages used by J2534 API
     class SMsg(ctypes.Structure):
@@ -154,3 +160,10 @@ class J2534API:
 
     def SBusCanClose(self):
         return self.j2534_dll.PassThruClose(self.device_id)
+
+    def reset_rx_stats(self):
+        """Reset internal RX statistics counters."""
+        self.total_rx = 0
+        self.rx_rate = 0
+        self._rx_sec_counter = 0
+        self._rx_sec_start = time.time()


### PR DESCRIPTION
## Summary
- support resetting RX counters in the J2534 Sloki driver
- expose reset_rx_stats through CANInterface
- reset driver counters when resetting frame counts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b780e2f4c8331b6dd8e0f94179c24