### PR TITLE
Load Sloki DLL path from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ can_diagnostic_tool/
 - cantools
 - pyqtgraph (for plotting)
 - pywin32 (for Windows GPS API)
+
+## Environment Variables
+
+- `SLOKI_DLL_PATH` – Optional override for the path to the Sloki `sBus-J2534.dll`. If not set, the driver defaults to `C:\Program Files (x86)\Sloki\SBUS\lib\x64\sBus-J2534.dll`.

--- a/hardware/drivers/j2534_sloki_driver.py
+++ b/hardware/drivers/j2534_sloki_driver.py
@@ -23,9 +23,11 @@ class CANFrame:
 
 class J2534API:
     def __init__(self):
-        # --- NOTE: Hardcoded path for Sloki DLL. ---
-        # TODO: Future improvement: Load DLL path from config or allow user selection.
-        self.j2534_dll = ctypes.WinDLL(r'C:\Program Files (x86)\Sloki\SBUS\lib\x64\sBus-J2534.dll')
+        # Path to the Sloki J2534 DLL. Can be overridden via the
+        # ``SLOKI_DLL_PATH`` environment variable.
+        default_path = r'C:\Program Files (x86)\Sloki\SBUS\lib\x64\sBus-J2534.dll'
+        dll_path = os.getenv('SLOKI_DLL_PATH', default_path)
+        self.j2534_dll = ctypes.WinDLL(dll_path)
         self.device_id = ctypes.c_ulong()
         self.channel_id = ctypes.c_ulong()
 


### PR DESCRIPTION
## Summary
- allow overriding the Sloki sBus-J2534.dll path through `SLOKI_DLL_PATH`
- document the new environment variable in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b7813c84c8331b7da7e85b9b5f5c0