### PR TITLE
Add batch reception support

### DIFF
--- a/hardware/can_interface.py
+++ b/hardware/can_interface.py
@@ -31,11 +31,19 @@ class CANInterface:
         frame.data = data
         return self.api.SBusCanSendMgs(frame)
 
+
     def receive(self, timeout=10):
-        status, frame = self.api.SBusCanReadMgs(timeout)
-        if status == 0:
-            return frame
+        status, frames = self.api.SBusCanReadMgs(timeout=timeout, max_msgs=1)
+        if status == 0 and frames:
+            return frames[0]
         return None
+
+    def receive_batch(self, timeout=10, max_frames=50):
+        """Return a list of received CANFrame objects."""
+        status, frames = self.api.SBusCanReadMgs(timeout=timeout, max_msgs=max_frames)
+        if status == 0:
+            return frames
+        return []
 
     def set_filter(self, can_id):
         return self.api.SBusCanRxSetFilter(can_id)

--- a/threads/receiver_thread.py
+++ b/threads/receiver_thread.py
@@ -11,10 +11,11 @@ class CANReceiverThread(QThread):
 
     def run(self):
         while self._running:
-            # Block for up to 10 ms, return earlier if a frame is available
-            frame = self.can_interface.receive(timeout=10)
-            if frame:
+            frames = self.can_interface.receive_batch(timeout=1, max_frames=50)
+            for frame in frames:
                 self.frame_received.emit(frame)
+            # Short delay to prevent busy waiting
+            self.msleep(1)
 
     def stop(self):
         self._running = False


### PR DESCRIPTION
## Summary
- allow reading multiple CAN frames per call in the Sloki driver
- wrap new driver API with `receive_batch` helper
- update the receiver thread to consume batches of frames

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_687dd6974a78833186c1aa2a9c9cc3a1