### PR TITLE
Add baudrate debug prints

### DIFF
--- a/hardware/can_interface.py
+++ b/hardware/can_interface.py
@@ -17,6 +17,8 @@ class CANInterface:
         self._stats_start = time.time()
         self._frames_received = 0
         self._load_driver_from_config()
+        # ensure current_baudrate reflects the value from config.json
+        self.current_baudrate = self.default_baudrate
 
     def _load_driver_from_config(self):
         if not CONFIG_PATH.exists():
@@ -40,7 +42,7 @@ class CANInterface:
         baudrate = baudrate or self.default_baudrate
         self.current_baudrate = baudrate
         print(f"[DEBUG] Connecting with baudrate: {baudrate}")
-        print("[DEBUG] Network statistics will be displayed every second")
+        print("[DEBUG] Network statistics will be displayed every second (frames/min)")
 
         self._stats_start = time.time()
         self._frames_received = 0
@@ -70,8 +72,9 @@ class CANInterface:
                 elapsed = time.time() - self._stats_start
                 if elapsed >= 1:
                     fps = self._frames_received / elapsed
+                    fpm = fps * 60
                     print(
-                        f"[DEBUG] {fps:.1f} frames/s at {self.current_baudrate} baud"
+                        f"[DEBUG] {fpm:.1f} frames/min at {self.current_baudrate} baud"
                     )
                     self._frames_received = 0
                     self._stats_start = time.time()

--- a/hardware/can_interface.py
+++ b/hardware/can_interface.py
@@ -34,6 +34,7 @@ class CANInterface:
             raise Exception("⚠️ Driver not initialized.")
 
         baudrate = baudrate or self.default_baudrate
+        print(f"[DEBUG] Connecting with baudrate: {baudrate}")
 
         self.driver.open()
         self.driver.connect(baudrate=baudrate)

--- a/ui/hardware_page.py
+++ b/ui/hardware_page.py
@@ -32,6 +32,8 @@ class HardwarePage(QWidget):
         self.baudrate_input = QComboBox()
         self.baudrate_input.addItems(["125000", "250000", "500000", "1000000"])
         self.baudrate_input.setCurrentText("500000")
+        self._current_baudrate = self.baudrate_input.currentText()
+        self.baudrate_input.currentTextChanged.connect(self.on_baudrate_change)
         self.layout().addWidget(QLabel("Select Baudrate:"))
         self.layout().addWidget(self.baudrate_input)
 
@@ -83,3 +85,9 @@ class HardwarePage(QWidget):
 
             except Exception as e:
                 self.status_label.setText(f"⚠️ Failed to load config: {e}")
+
+    def on_baudrate_change(self, new_baudrate):
+        print(
+            f"[DEBUG] Baudrate changed from {self._current_baudrate} to {new_baudrate}"
+        )
+        self._current_baudrate = new_baudrate


### PR DESCRIPTION
## Summary
- report baudrate changes in the hardware page
- print baudrate when connecting to the CAN driver

## Testing
- `python -m py_compile ui/hardware_page.py hardware/can_interface.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f311316fc833199639db0dac303a9