### PR TITLE
Add PySide6 CAN performance stats GUI

### DIFF
--- a/PEAK_VS_Sloki_benchmark/Sloki_performance.py
+++ b/PEAK_VS_Sloki_benchmark/Sloki_performance.py
@@ -1,1 +1,64 @@
-# Sloki_performance.py
+"""Utilities for measuring CAN frame statistics.
+
+This module exposes the :class:`CANStats` class which tracks the count and
+cycle time for each CAN identifier observed on the bus.  The class is
+thread-safe so it can be updated from a background thread while a GUI displays
+the statistics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Dict
+import time
+
+
+@dataclass
+class _StatEntry:
+    count: int = 0
+    last_time: float | None = None
+    cycle_time_ms: float = 0.0
+
+
+class CANStats:
+    """Track count and cycle time for CAN identifiers."""
+
+    def __init__(self) -> None:
+        self._stats: Dict[int, _StatEntry] = {}
+        self._lock = Lock()
+
+    def update(self, can_id: int) -> None:
+        """Record reception of *can_id* at the current time."""
+        now = time.time()
+        with self._lock:
+            entry = self._stats.get(can_id)
+            if entry is None:
+                entry = _StatEntry(count=1, last_time=now, cycle_time_ms=0.0)
+                self._stats[can_id] = entry
+            else:
+                if entry.last_time is not None:
+                    entry.cycle_time_ms = (now - entry.last_time) * 1000.0
+                entry.last_time = now
+                entry.count += 1
+
+    def snapshot(self) -> Dict[int, Dict[str, float | int]]:
+        """Return a snapshot of the collected statistics.
+
+        The result maps CAN identifiers to dictionaries containing ``count`` and
+        ``cycle_time_ms`` entries.  The snapshot is safe to use without holding
+        the internal lock.
+        """
+
+        with self._lock:
+            return {
+                can_id: {
+                    "count": entry.count,
+                    "cycle_time_ms": entry.cycle_time_ms,
+                }
+                for can_id, entry in self._stats.items()
+            }
+
+
+__all__ = ["CANStats"]
+

--- a/PEAK_VS_Sloki_benchmark/Sloki_performance_gui.py
+++ b/PEAK_VS_Sloki_benchmark/Sloki_performance_gui.py
@@ -1,0 +1,99 @@
+"""PySide6 GUI for displaying CAN frame statistics."""
+
+from __future__ import annotations
+
+import sys
+from PySide6.QtCore import QTimer, Qt, QThread
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QTableWidget,
+    QTableWidgetItem,
+    QAbstractItemView,
+    QHeaderView,
+)
+
+from hardware.drivers.j2534_sloki_driver import J2534API
+from Sloki_performance import CANStats
+
+
+class CANReaderThread(QThread):
+    """Background thread that reads CAN frames and updates statistics."""
+
+    def __init__(self, stats: CANStats, japi: J2534API, parent=None) -> None:
+        super().__init__(parent)
+        self._stats = stats
+        self._japi = japi
+        self._running = True
+
+    def run(self) -> None:
+        if self._japi.SBusCanOpen() != 0:
+            return
+        if self._japi.SBusCanConnect(J2534API.Protocol_ID.CAN.value, 500000) != 0:
+            return
+        self._japi.SBusCanClearRxMsg()
+        while self._running:
+            status, frame = self._japi.SBusCanReadMgs(10)
+            if status == 0:
+                self._stats.update(frame.CAN_ID)
+
+    def stop(self) -> None:
+        self._running = False
+
+
+class StatsWindow(QMainWindow):
+    """Main window displaying CAN statistics in a table."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Sloki CAN Performance")
+
+        self._stats = CANStats()
+        self._japi = J2534API()
+        self._reader = CANReaderThread(self._stats, self._japi)
+
+        self._table = QTableWidget(0, 3, self)
+        self._table.setHorizontalHeaderLabels(["CAN ID", "Cycle Time (ms)", "Count"])
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.setCentralWidget(self._table)
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._refresh)
+        self._timer.start(300)
+
+        self._reader.start()
+
+    def _refresh(self) -> None:
+        data = self._stats.snapshot()
+        self._table.setRowCount(len(data))
+        for row, (can_id, info) in enumerate(sorted(data.items())):
+            can_item = QTableWidgetItem(f"{can_id:08X}")
+            cycle_item = QTableWidgetItem(f"{info['cycle_time_ms']:.2f}")
+            count_item = QTableWidgetItem(str(info['count']))
+            can_item.setTextAlignment(Qt.AlignCenter)
+            cycle_item.setTextAlignment(Qt.AlignCenter)
+            count_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 0, can_item)
+            self._table.setItem(row, 1, cycle_item)
+            self._table.setItem(row, 2, count_item)
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        self._timer.stop()
+        self._reader.stop()
+        self._reader.wait()
+        self._japi.SBusCanDisconnect()
+        self._japi.SBusCanClose()
+        super().closeEvent(event)
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    window = StatsWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Implement thread-safe `CANStats` helper for tracking CAN message counts and cycle times
- Add `Sloki_performance_gui` PySide6 app with background CAN reader thread and live table of CAN IDs

## Testing
- `python -m py_compile PEAK_VS_Sloki_benchmark/Sloki_performance.py PEAK_VS_Sloki_benchmark/Sloki_performance_gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c102c16083319c2f402be6096c95