### PR TITLE
Add lazy DBC loader and getter

### DIFF
--- a/CAN_diagnostic_tool/Released/dbc_page.py
+++ b/CAN_diagnostic_tool/Released/dbc_page.py
@@ -1,10 +1,9 @@
 # dbc_page.py
-"""
-Central place to load and share the DBC database.
+"""Central place to load and share the DBC database.
 
 • Looks for the file right next to this script (same folder).
 • Raises a clear error if it’s missing.
-• Exports: BASE_DIR, DBC_PATH, dbc
+• Exports: BASE_DIR, DBC_PATH, load_dbc
 """
 
 from pathlib import Path
@@ -15,13 +14,21 @@ DBC_FILENAME = "DBC_sample_cantools.dbc"   # change here if you rename the file
 # ----------------------------------------------------------------------------
 
 # Folder where this .py file lives (e.g., CAN_diagnostic_tool/)
-BASE_DIR  = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent
 DBC_PATH = BASE_DIR / DBC_FILENAME
 
 if not DBC_PATH.exists():
     raise FileNotFoundError(f"DBC file not found: {DBC_PATH}")
 
-# Load it once; share the loaded database object everywhere
-dbc = cantools.database.load_file(DBC_PATH)
+_dbc_cache = None
 
-__all__ = ["BASE_DIR", "DBC_PATH", "dbc"]
+
+def load_dbc():
+    """Return the loaded DBC database, loading it on first use."""
+    global _dbc_cache
+    if _dbc_cache is None:
+        _dbc_cache = cantools.database.load_file(DBC_PATH)
+    return _dbc_cache
+
+
+__all__ = ["BASE_DIR", "DBC_PATH", "load_dbc"]

--- a/CAN_diagnostic_tool/Released/imp_params.py
+++ b/CAN_diagnostic_tool/Released/imp_params.py
@@ -12,7 +12,9 @@ from PySide6.QtWidgets import (
 )
 
 from PEAK_API import get_config_and_bus
-from dbc_page  import dbc, DBC_PATH
+from dbc_page import load_dbc, DBC_PATH
+
+dbc = load_dbc()
 
 
 # ─── Signal groups ──────────────────────────────────────────────────────────

--- a/CAN_diagnostic_tool/Sloki_API.py
+++ b/CAN_diagnostic_tool/Sloki_API.py
@@ -26,8 +26,9 @@ from typing import Dict, Tuple, Optional, Sequence, Set
 from collections import namedtuple
 import ctypes
 import time
-from dbc_page import dbc, DBC_PATH
+from dbc_page import load_dbc, DBC_PATH
 
+dbc = load_dbc()
 print(f"Loaded DBC: {DBC_PATH}  (messages: {len(dbc.messages)})")
 
 # ── SimpleMessage (shared shape with PEAK version) ────────────

--- a/CAN_diagnostic_tool/dbc_page.py
+++ b/CAN_diagnostic_tool/dbc_page.py
@@ -11,7 +11,15 @@ DBC_PATH = BASE_DIR / "data" / "DBC_sample_cantools.dbc"
 if not DBC_PATH.exists():
     raise FileNotFoundError(f"DBC not found at: {DBC_PATH}")
 
-# Load once and export for reuse
-dbc = cantools.database.load_file(DBC_PATH)
+_dbc_cache = None
 
-__all__ = ["BASE_DIR", "DBC_PATH", "dbc"]
+
+def load_dbc():
+    """Return the loaded DBC database, loading it on first use."""
+    global _dbc_cache
+    if _dbc_cache is None:
+        _dbc_cache = cantools.database.load_file(DBC_PATH)
+    return _dbc_cache
+
+
+__all__ = ["BASE_DIR", "DBC_PATH", "load_dbc"]

--- a/CAN_diagnostic_tool/imp_params.py
+++ b/CAN_diagnostic_tool/imp_params.py
@@ -12,7 +12,9 @@ from PySide6.QtWidgets import (
 )
 
 from PEAK_API import get_config_and_bus
-from dbc_page  import dbc, DBC_PATH
+from dbc_page import load_dbc, DBC_PATH
+
+dbc = load_dbc()
 
 
 # ─── Signal groups ──────────────────────────────────────────────────────────

--- a/CAN_diagnostic_tool/live_signal_viewer.py
+++ b/CAN_diagnostic_tool/live_signal_viewer.py
@@ -10,9 +10,10 @@ from PySide6.QtWidgets import (
 )
 
 from PEAK_API import get_config_and_bus
-from dbc_page import dbc, DBC_PATH
+from dbc_page import load_dbc, DBC_PATH
 
 cfg, BUS = get_config_and_bus()
+dbc = load_dbc()
 
 print(f"Loaded DBC: {DBC_PATH}  (messages: {len(dbc.messages)})")
 


### PR DESCRIPTION
## Summary
- add `load_dbc()` helper that caches the parsed DBC file
- use `load_dbc()` in diagnostic tools instead of importing a global `dbc`

## Testing
- `python -m py_compile CAN_diagnostic_tool/Released/dbc_page.py CAN_diagnostic_tool/dbc_page.py CAN_diagnostic_tool/Released/imp_params.py CAN_diagnostic_tool/imp_params.py CAN_diagnostic_tool/Sloki_API.py CAN_diagnostic_tool/live_signal_viewer.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6895bb30cbe88331896d2555c268e823