### PR TITLE
Transmit page

### DIFF
--- a/CAN_diagnostic_tool/PEAK_API.py
+++ b/CAN_diagnostic_tool/PEAK_API.py
@@ -41,6 +41,14 @@ def _make_real_bus(settings):
                                  msg.is_extended_id,
                                  msg.data,
                                  msg.timestamp)
+        def send(self, arbitration_id: int, is_extended_id: bool, data: bytes):
+            message = can.Message(
+                arbitration_id=arbitration_id,
+                is_extended_id=is_extended_id,
+                data=bytes(data),
+                is_fd=settings["USE_CAN_FD"],
+            )
+            real_bus.send(message)
         def shutdown(self):
             real_bus.shutdown()
     return WrappedBus()
@@ -51,6 +59,9 @@ class DummyBus:
     def recv(self, timeout: float = 0.1):
         import time; time.sleep(timeout)
         return None
+    def send(self, arbitration_id: int, is_extended_id: bool, data: bytes):
+        # no-op in dummy mode
+        pass
     def shutdown(self):
         pass
 

--- a/CAN_diagnostic_tool/live_signal_transmit.py
+++ b/CAN_diagnostic_tool/live_signal_transmit.py
@@ -1,0 +1,21 @@
+import sys
+from PySide6.QtWidgets import QApplication, QMainWindow
+
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Live Signal Transmit")
+        self.resize(900, 600)
+
+
+def main():
+    app = QApplication(sys.argv)
+    win = MainWindow(); win.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/CAN_diagnostic_tool/live_signal_transmit.py
+++ b/CAN_diagnostic_tool/live_signal_transmit.py
@@ -1,12 +1,205 @@
 import sys
-from PySide6.QtWidgets import QApplication, QMainWindow
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QComboBox, QPushButton, QGroupBox, QFormLayout, QRadioButton,
+    QButtonGroup, QSlider, QDoubleSpinBox, QMessageBox, QScrollArea
+)
+
+from dbc_page import dbc
+from PEAK_API import get_config_and_bus
+
+
+cfg, BUS = get_config_and_bus()
+
+
+def _compute_physical_bounds(length_bits: int, is_signed: bool, scale: float, offset: float,
+                             smin: Optional[float], smax: Optional[float]) -> Tuple[float, float]:
+    if smin is not None and smax is not None:
+        return float(smin), float(smax)
+    if is_signed:
+        raw_min = -(2 ** (length_bits - 1))
+        raw_max = (2 ** (length_bits - 1)) - 1
+    else:
+        raw_min = 0
+        raw_max = (2 ** length_bits) - 1
+    phys_min = raw_min * scale + offset
+    phys_max = raw_max * scale + offset
+    if phys_min > phys_max:
+        phys_min, phys_max = phys_max, phys_min
+    return float(phys_min), float(phys_max)
+
+
+def _decimals_for_step(step: float) -> int:
+    s = f"{step:.10f}".rstrip("0").split(".")
+    return len(s[1]) if len(s) > 1 else 0
+
+
+@dataclass
+class SignalEditor:
+    name: str
+    widget: QWidget
+    get_value: Callable[[], float]
 
 
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Live Signal Transmit")
-        self.resize(900, 600)
+        self.resize(1100, 700)
+
+        # Top: message selector and info
+        top_row = QHBoxLayout()
+        top_row.addWidget(QLabel("Message:"))
+        self.msg_combo = QComboBox()
+        for m in dbc.messages:
+            self.msg_combo.addItem(m.name)
+        self.msg_combo.currentIndexChanged.connect(self._on_message_changed)
+        top_row.addWidget(self.msg_combo, 1)
+
+        self.msg_id_label = QLabel("")
+        top_row.addWidget(self.msg_id_label)
+
+        self.transmit_btn = QPushButton("Transmit")
+        self.transmit_btn.clicked.connect(self._transmit_once)
+        top_row.addWidget(self.transmit_btn)
+
+        # Center: dynamic signal editors inside a scroll area
+        self.form = QFormLayout()
+        self.form_group = QGroupBox("Signals")
+        self.form_group.setLayout(self.form)
+        scroll = QScrollArea(); scroll.setWidgetResizable(True)
+        container = QWidget(); v = QVBoxLayout(); v.addWidget(self.form_group); v.addStretch(); container.setLayout(v)
+        scroll.setWidget(container)
+
+        root_layout = QVBoxLayout()
+        root_layout.addLayout(top_row)
+        root_layout.addWidget(scroll)
+        root = QWidget(); root.setLayout(root_layout)
+        self.setCentralWidget(root)
+
+        self._signal_editors: Dict[str, SignalEditor] = {}
+        self._on_message_changed()
+
+    # ---- UI builders ----------------------------------------------------
+    def _clear_form(self):
+        while self.form.rowCount():
+            self.form.removeRow(0)
+        self._signal_editors.clear()
+
+    def _on_message_changed(self):
+        self._clear_form()
+        mdef = self._current_message()
+        if mdef is None:
+            return
+        frame_id = mdef.frame_id
+        self.msg_id_label.setText(f"ID: 0x{frame_id:X} {'(EXT)' if mdef.is_extended_frame else ''}")
+
+        for sig in mdef.signals:
+            editor = self._create_signal_editor(sig)
+            self._signal_editors[editor.name] = editor
+            self.form.addRow(QLabel(f"{sig.name} ({sig.length}b)"), editor.widget)
+
+    def _create_signal_editor(self, sig) -> SignalEditor:
+        # 1-bit → radio buttons (0/1)
+        if sig.length == 1 and ((sig.scale == 1 and (sig.minimum, sig.maximum) == (0, 1)) or (sig.minimum is None and sig.maximum is None)):
+            row = QWidget(); h = QHBoxLayout(); row.setLayout(h)
+            zero = QRadioButton("0"); one = QRadioButton("1")
+            zero.setChecked(True)
+            group = QButtonGroup(row); group.addButton(zero, 0); group.addButton(one, 1)
+            h.addWidget(zero); h.addWidget(one); h.addStretch()
+            return SignalEditor(sig.name, row, lambda g=group: float(g.checkedId()))
+
+        # General numeric → slider + spinbox
+        scale = float(sig.scale or 1.0)
+        offset = float(sig.offset or 0.0)
+        pmin, pmax = _compute_physical_bounds(sig.length, sig.is_signed, scale, offset, sig.minimum, sig.maximum)
+        if pmin == pmax:
+            pmax = pmin + scale
+        step = abs(scale) if scale != 0 else 1.0
+        decimals = min(6, max(0, _decimals_for_step(step)))
+
+        row = QWidget(); h = QHBoxLayout(); row.setLayout(h)
+        slider = QSlider(Qt.Horizontal)
+        spin = QDoubleSpinBox(); spin.setDecimals(decimals)
+        spin.setRange(pmin, pmax)
+        spin.setSingleStep(step)
+
+        # Map slider positions to physical range with up to 1000 steps
+        total_steps_exact = int(round((pmax - pmin) / step))
+        slider_steps = max(1, min(1000, total_steps_exact))
+        slider.setRange(0, slider_steps)
+
+        def slider_to_phys(pos: int) -> float:
+            if slider_steps == 0:
+                return pmin
+            ratio = pos / slider_steps
+            val = pmin + ratio * (pmax - pmin)
+            # snap to resolution
+            snapped = round((val - pmin) / step) * step + pmin
+            return max(pmin, min(pmax, snapped))
+
+        def phys_to_slider(val: float) -> int:
+            val = max(pmin, min(pmax, val))
+            if pmax == pmin:
+                return 0
+            ratio = (val - pmin) / (pmax - pmin)
+            return int(round(ratio * slider_steps))
+
+        # sync both directions
+        def on_slider_changed(pos: int):
+            spin.blockSignals(True)
+            spin.setValue(slider_to_phys(pos))
+            spin.blockSignals(False)
+
+        def on_spin_changed(val: float):
+            slider.blockSignals(True)
+            slider.setValue(phys_to_slider(val))
+            slider.blockSignals(False)
+
+        slider.valueChanged.connect(on_slider_changed)
+        spin.valueChanged.connect(on_spin_changed)
+
+        # initial
+        on_spin_changed(pmin)
+
+        h.addWidget(slider, 2)
+        h.addWidget(spin, 1)
+
+        return SignalEditor(sig.name, row, lambda s=spin: float(s.value()))
+
+    # ---- actions ---------------------------------------------------------
+    def _current_message(self):
+        idx = self.msg_combo.currentIndex()
+        if idx < 0:
+            return None
+        return dbc.messages[idx]
+
+    def _transmit_once(self):
+        mdef = self._current_message()
+        if mdef is None:
+            return
+        values: Dict[str, float] = {}
+        for name, editor in self._signal_editors.items():
+            try:
+                values[name] = editor.get_value()
+            except Exception as ex:
+                QMessageBox.warning(self, "Input Error", f"Failed to read value for {name}: {ex}")
+                return
+        try:
+            payload = mdef.encode(values)
+        except Exception as ex:
+            QMessageBox.critical(self, "Encode Error", f"Failed to encode message:\n{ex}")
+            return
+        try:
+            BUS.send(mdef.frame_id, mdef.is_extended_frame, bytes(payload))
+        except Exception as ex:
+            QMessageBox.critical(self, "Transmit Error", f"Hardware send failed:\n{ex}")
+            return
+        QMessageBox.information(self, "Transmit", "Message sent.")
 
 
 def main():

--- a/CAN_diagnostic_tool/main.py
+++ b/CAN_diagnostic_tool/main.py
@@ -32,10 +32,14 @@ class HomeWindow(QMainWindow):
         self.params_btn = QPushButton("Important Parameters", clicked=self.open_params)
         self.params_btn.setFixedHeight(50)
 
+        self.tx_btn = QPushButton("Live Signal Transmit", clicked=self.open_transmit)
+        self.tx_btn.setFixedHeight(50)
+
         layout = QVBoxLayout()
         layout.addStretch()
         layout.addWidget(self.viewer_btn)
         layout.addWidget(self.params_btn)
+        layout.addWidget(self.tx_btn)
         layout.addStretch()
 
         root = QWidget(); root.setLayout(layout)
@@ -44,6 +48,7 @@ class HomeWindow(QMainWindow):
         # keep references so the windows aren’t garbage-collected
         self._viewer    = None    # type: ignore
         self._imp_param = None    # type: ignore
+        self._tx_window = None    # type: ignore
 
     # ── helpers ─────────────────────────────────────────────────────────────
     def _load_window(self, module_name: str, attr: str):
@@ -65,12 +70,21 @@ class HomeWindow(QMainWindow):
             self._imp_param.destroyed.connect(self._child_closed)
         self._imp_param.show(); self.hide()
 
+    def open_transmit(self):
+        if self._tx_window is None:
+            TxClass = self._load_window("live_signal_transmit", "MainWindow")
+            self._tx_window = TxClass()
+            self._tx_window.destroyed.connect(self._child_closed)
+        self._tx_window.show(); self.hide()
+
     def _child_closed(self):
         """Called when either child window is destroyed."""
         if self.sender() is self._viewer:
             self._viewer = None
         elif self.sender() is self._imp_param:
             self._imp_param = None
+        elif self.sender() is self._tx_window:
+            self._tx_window = None
         self.show()
 
 


### PR DESCRIPTION
This pull request adds a new "Live Signal Transmit" feature to the CAN diagnostic tool, allowing users to interactively transmit CAN messages with custom signal values from a graphical interface. It introduces a new window for this functionality, integrates it into the main application, and updates the CAN bus API to support message transmission. The most important changes are grouped below:

**New Feature: Live Signal Transmit Window**

* Added a new file `live_signal_transmit.py` implementing a PySide6-based GUI for live editing and transmission of CAN signals. This window provides a table of all signals, value editors, enable/disable controls, per-signal cycle time, and live transmission scheduling. It uses the DBC definitions and the CAN bus API for encoding and sending messages.
* Integrated the new "Live Signal Transmit" window into the main application by adding a button (`self.tx_btn`) and corresponding logic to open and manage the window in `main.py`. [[1]](diffhunk://#diff-5a0b90e90f6ac5ae7b35b2fbf9a61ca4c2c3ae1315f78d58d0089fbfa301ed3aR35-R42) [[2]](diffhunk://#diff-5a0b90e90f6ac5ae7b35b2fbf9a61ca4c2c3ae1315f78d58d0089fbfa301ed3aR51) [[3]](diffhunk://#diff-5a0b90e90f6ac5ae7b35b2fbf9a61ca4c2c3ae1315f78d58d0089fbfa301ed3aR73-R87)

**CAN Bus API Enhancements**

* Added a `send` method to both the real and dummy CAN bus wrappers in `PEAK_API.py`, allowing the GUI to transmit messages via the bus abstraction. The dummy implementation is a no-op for testability. [[1]](diffhunk://#diff-371c3ce7b10f1b052f9d103b015c8dae8c3d04d684d07135b92db6ce574ee01eR44-R51) [[2]](diffhunk://#diff-371c3ce7b10f1b052f9d103b015c8dae8c3d04d684d07135b92db6ce574ee01eR62-R64)